### PR TITLE
Adjust extraction of package version from debian/changelog.

### DIFF
--- a/git2deb
+++ b/git2deb
@@ -82,7 +82,8 @@ fi
 
 (
   readonly pkgname=$(grep -- ^Source: debian/control | cut -d' ' -f2)
-  readonly pkgversion=$(head -n1 -- debian/changelog | cut -d' ' -f2 | tr -d '()' | cut -d- -f1)
+  #readonly pkgversion=$(head -n1 -- debian/changelog | cut -d' ' -f2 | tr -d '()' | cut -d- -f1)
+  readonly pkgversion=$(sed -rn "s/^.*\(([^)]+)\).*$/\1/;s/-[^-]+$//p;q"  debian/changelog)
 
   # Ensure DEBFULLNAME and DEBEMAIL are set, needed by dh_make
   [[ -z ${DEBFULLNAME+x} ]] && export DEBFULLNAME=root
@@ -102,7 +103,7 @@ fi
 
   # Build an unsigned package
   dpkg-buildpackage -us -uc
-) 
+)
 
 # Move the .deb, .changes and .dsc files into the script's original working directory
 cd "$tmpdir" && mv -n -- *.{deb,changes,dsc} "${scripthome}/"


### PR DESCRIPTION
Package version numbers are permitted to contain hyphens. 
https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
The sed command removes only the section after and including the last hyphen.